### PR TITLE
委托任务时只显示正常状态的用户

### DIFF
--- a/bc-workflow-core/src/main/resources/META-INF/resources/bc-workflow/todo/view.js
+++ b/bc-workflow-core/src/main/resources/META-INF/resources/bc-workflow/todo/view.js
@@ -28,6 +28,7 @@ bc.todoView = {
 				// 选择委托人
 				bc.identity.selectUser({
 					history: false,
+					status: "0",
 					onOk : function(user) {
 						jQuery.ajax({
 							url: bc.root + "/bc-workflow/workflow/delegateTask", 


### PR DESCRIPTION
修正“待办任务”模块委托任务的弹窗显示禁用状态的用户信息