### PR TITLE
添加可发送 HTTP 请求监听器 - SendHttpRequestListener

### DIFF
--- a/bc-workflow-core/src/main/java/cn/bc/workflow/activiti/delegate/SendHttpRequestListener.java
+++ b/bc-workflow-core/src/main/java/cn/bc/workflow/activiti/delegate/SendHttpRequestListener.java
@@ -1,0 +1,179 @@
+package cn.bc.workflow.activiti.delegate;
+
+import cn.bc.core.exception.CoreException;
+import cn.bc.core.util.JsonUtils;
+import cn.bc.spider.Result;
+import cn.bc.spider.callable.BaseCallable;
+import cn.bc.spider.http.TaskExecutor;
+import org.activiti.engine.delegate.DelegateExecution;
+import org.activiti.engine.delegate.DelegateTask;
+import org.activiti.engine.delegate.TaskListener;
+import org.activiti.engine.delegate.VariableScope;
+import org.activiti.engine.impl.el.Expression;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.jsoup.helper.StringUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 调用可发起 HTTP 请求的监听器
+ *
+ * @author zf
+ */
+public class SendHttpRequestListener extends ExcutionLogListener implements TaskListener {
+  protected final Log logger = LogFactory.getLog(getClass());
+
+  /**
+   * 是否执行请求的发送
+   */
+  private Expression ignore;
+  /**
+   * 请求方法，如 GET
+   */
+  private Expression method;
+  /**
+   * 请求的 url，如 http://192.168.0.222/financial/pay-plan/
+   */
+  private Expression url;
+  /**
+   * 要发送的请求头，jwt 头系统内部自动添加，这里配置自定义头
+   */
+  private Expression headers;
+  /**
+   * 要发送的请求体
+   */
+  private Expression body;
+  /**
+   * 请求发送后响应成功的响应码，默认 2xx
+   */
+  private Expression successStatusCode;
+  /**
+   * 调用此监听器的模块类型，作为模块与流程关联的标识，如：PayPlan
+   */
+  private Expression mtype;
+  /**
+   * 需要获取的响应数据名称，如：Connection，Location, body
+   */
+  private Expression response;
+
+  @Override
+  public void notify(DelegateExecution execution) {
+    // 判断是否执行发送请求
+    Boolean ignoreValue = ignore == null || (ignore.getExpressionText().contains("$") ? (Boolean) ignore.getValue(execution) : Boolean.parseBoolean(ignore.getExpressionText()));
+    // 判断是否执行请求的发送
+    if (!ignoreValue) {
+      logger.debug("ignore = false，无需执行请求的发送");
+    } else {
+      buildRequest(execution);
+    }
+  }
+
+  @Override
+  public void notify(DelegateTask execution) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("execution=" + execution.getClass());
+      logger.debug("this=" + this.getClass());
+      logger.debug("id=" + execution.getId());
+      logger.debug("eventName=" + execution.getEventName());
+      logger.debug("processInstanceId" + execution.getProcessInstanceId());
+      logger.debug("executionId=" + execution.getExecutionId());
+      logger.debug("taskDefinitionKey=" + execution.getTaskDefinitionKey());
+    }
+    // 判断是否执行发送请求
+    Boolean ignoreValue = ignore == null || (ignore.getExpressionText().contains("$") ? (Boolean) ignore.getValue(execution) : Boolean.parseBoolean(ignore.getExpressionText()));
+    // 判断是否执行请求的发送
+    if (!ignoreValue) {
+      logger.debug("ignore = false，无需执行请求的发送");
+    } else {
+      buildRequest(execution);
+    }
+  }
+
+  private void buildRequest(VariableScope execution) {
+    String methodValue = method != null ? (String) method.getValue(execution) : null;
+    int Status = successStatusCode != null ? (successStatusCode.getExpressionText().contains("$") ? ((Long) successStatusCode.getValue(execution)).intValue() : Integer.parseInt(successStatusCode.getExpressionText())) : 200;
+    String[] responseArray = response != null && !StringUtil.isBlank((String) response.getValue(execution)) ? ((String) response.getValue(execution)).replaceAll("\\s*", "").split(",") : null;
+    String moduleTypeValue = mtype != null ? (String) mtype.getValue(execution) : null;
+
+    // 构建同步分期还款请求
+    BaseCallable callable = new BaseCallable() {
+      @Override
+      protected int getSuccessStatusCode() {
+        return Status;
+      }
+
+      @Override
+      protected Result defaultBadResult(CloseableHttpResponse response) {
+        Result result = super.defaultBadResult(response);
+        try {
+          // 请求失败，返回请求体包含的信息
+          String Response = getResponseText();
+          if (!StringUtil.isBlank(Response)) result = new Result<>(false, Response);
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+        return result;
+      }
+
+      @Override
+      public Object parseResponse() throws Exception {
+        if (responseArray != null) {
+          Map<String, String> responseMap = new HashMap<>();
+          for (String k : responseArray) {
+            // 请求体信息， body 作为 key
+            if (k.equalsIgnoreCase("body")) responseMap.put("body", getResponseText());
+              // 请求头信息，'k' 作为 key，如：Location
+            else responseMap.put(k, getResponseHeader(k));
+          }
+          // 以 Map 形式返回需要的 response
+          return responseMap;
+        } else {
+          // 以 String 形式返回请求体信息
+          return getResponseText();
+        }
+      }
+    };
+
+    // 设置请求参数
+    callable.setMethod(methodValue);
+    callable.setUrl((String) url.getValue(execution));
+    Map<String, Object> headersMap = JsonUtils.toMap((String) headers.getValue(execution));
+    callable.addHeader(headersMap);
+    callable.setPayload(body.getValue(execution));
+    Result result = TaskExecutor.get(callable);
+    if (result.isSuccess()) {
+      if ("POST".equalsIgnoreCase(methodValue) && responseArray != null) {
+        // 以 responseArray 的值作为 key，解析相应 response 的值作为 value
+        Map<String, Object> resultData = getResultData((Map<String, Object>) result.getData());
+        // 如果是 POST 请求，获取实体类 ID，并设置为全局参数
+        if (!resultData.isEmpty() && resultData.get("Location") != null) {
+          execution.setVariable("mid", resultData.get("Location"));
+          // 设置调用此监听器的模块标识
+          if (moduleTypeValue != null) execution.setVariable("mtype", moduleTypeValue);
+        }
+      }
+    } else {
+      logger.debug(methodValue + "/" + url.getValue(execution) + "请求发送成功，响应失败：" + result.getError());
+      throw new CoreException(methodValue + "/" + url.getValue(execution) + "请求发送成功，接口响应失败：" + result.getError());
+    }
+  }
+
+  private Map<String, Object> getResultData(Map<String, Object> data) {
+    Map<String, Object> result = new HashMap<>();
+    for (Map.Entry<String, Object> entry : data.entrySet()) {
+      if (null != entry.getValue() && !StringUtil.isBlank(entry.getValue().toString())) {
+        String value = entry.getValue().toString();
+        if (entry.getKey().equalsIgnoreCase("Location")) {
+          String newValue = value.substring(value.lastIndexOf("/") + 1);
+          result.put("Location", newValue);
+        } else {
+          result.put(entry.getKey(), value);
+        }
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
由于业务需求，添加可发送 HTTP 请求的监听器 `SendHttpRequestListener`；此监听器配置参数如下：
|  name                     |  Description
|----------------------|---------------
| ignore                     | 是否执行请求的发送
| method                  | 请求方法，如： GET
| url                           | 请求的 url，如： http://192.168.0.222/financial/pay-plan/
| headers                  | 要发送的请求头，jwt 头系统内部自动添加，这里配置自定义头
| body                       | 要发送的请求体
| successStatusCode | 请求发送后响应成功的响应码，默认 2xx
| response                | 需要获取的响应数据名称，如：Connection，Location, body
| mtype                    | 调用此监听器的模块类型，可作为模块与流程关联的标识，如：PayPlan

