### PR TITLE
扩展启动流程接口

### DIFF
--- a/bc-workflow-core/docs/rest-api.md
+++ b/bc-workflow-core/docs/rest-api.md
@@ -1,0 +1,47 @@
+# 流程引擎 Rest API
+
+Rest 的上下文路径 `{context-path}` 默认值为 `/bc-workflow`。
+以下的 Rest URL 路径均为相对于此路径下的子路径。如 `/a?p=v` 的实际访问路径应为 `{context-path}/a?p=v`。
+
+| SN | Method | Url                                | Description
+|----|--------|------------------------------------|-------------
+| 1  | POST   | /workflow/startFlow?key=x&id=x     | 启动流程
+
+## 1. 启动流程
+
+**请求：**
+```
+POST /workflow/startFlow?key=x&id=x
+Content-Type : application/x-www-form-urlencoded
+
+{mid=x&mtype=x&autoCompleteFirstTask=x&formData=x}
+```
+
+|  Name                 | Type    |  Description
+|-----------------------|---------|---------------
+| key                   | string  | 流程编码，如：PayPlanApproval
+| id                    | string  | 流程定义的主键，如：PayPlanApproval:1:16591403
+| mid                   | string  | 模块 ID，模块与流程关联标识之一，如：16
+| mtype                 | string  | 模块类型，模块与流程关联标识之一,如：PayPlan
+| autoCompleteFirstTask | boolean | 是否自动完成首个待办的办理，默认 false
+| formData              | string  | 流程变量集合，标准 json 格式，如：`[{"name":"driverId","value":"106194","type":"int","scope":"global"}…]`
+
+> 启动流程时选择 key 或 id 任意一个定义参数即可。
+> 启动流程需要携带流程变量才定义 formData，否则不需定义 formData。
+
+**响应：**
+
+```
+200 OK
+Content-Type : application/json
+
+{success：true，msg："启动成功!"，processInstance：$processInstanceId}
+```
+
+如果启动失败，响应返回：
+```
+200 OK
+Content-Type : application/json
+
+{success：false，msg：$e}
+```


### PR DESCRIPTION
原本启动流程接口是通过流程编码或流程主键直接启动流程，不支持携带业务数据，由于业务需求，导致得扩展启动流程接口，支持如下功能：
- 允许携带业务数据
- 可自动完成首个待办任务的办理  
- 流程与模块建立关联关系

具体请看[启动流程 Rest 接口设计](https://github.com/bcsoft/bc-workflow/pull/10/commits/663a84560a6e7a0040eb2765019b0400fdca787f)